### PR TITLE
Fix pdo_mysql non abilitato su php.ini

### DIFF
--- a/.docker/services/webserver/config/conf.d/php.ini
+++ b/.docker/services/webserver/config/conf.d/php.ini
@@ -6,6 +6,7 @@ display_errors=On
 ; EXTENSIONS
 extension=intl.so
 extension=mysqli.so
+extension=pdo_mysql.so
 extension=zip.so
 
 [date]


### PR DESCRIPTION
L'estensione viene correttamente installata dal comando nel [file docker](https://github.com/GDRCD/stack/blob/dev/.docker/services/webserver/version/php8/Dockerfile#L47) di php8 (e presumo anche per le altre versioni) ma nel php.ini non risultava abilitata e di conseguenza `dev6`, che dipende da pdo_mysql, non funziona